### PR TITLE
Do not set application name by default - it breaks Yahoo oauth.

### DIFF
--- a/EOAuthUserIdentity.php
+++ b/EOAuthUserIdentity.php
@@ -23,6 +23,8 @@ class EOAuthUserIdentity extends EOAuthComponent implements IUserIdentity {
      * @var string OAuth consumer secret. Defaults to 'anonymous'
      */
     public $secret='anonymous';
+    
+    public $applicationName;
 
     /**
      * @var array|class OAuthProvider configuration|class.
@@ -101,9 +103,6 @@ class EOAuthUserIdentity extends EOAuthComponent implements IUserIdentity {
             // Set the scope (must match service endpoint).
             $scope = $this->scope;
 
-            // Set the application name as it is displayed on the authorization page.
-            $applicationName = Yii::app()->name;
-
             // Use the URL of the current page as the callback URL.
             $protocol = (isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on")
                     ? 'https://' : 'http://';
@@ -113,7 +112,7 @@ class EOAuthUserIdentity extends EOAuthComponent implements IUserIdentity {
 
             // Get request token.
             $token = EOAuthUtils::GetRequestToken($consumer, $scope,
-                    $this->provider->request_token_endpoint, $applicationName, $callbackUrl);
+                    $this->provider->request_token_endpoint, $this->applicationName, $callbackUrl);
 
             // Store consumer and token in session.
             $session['OAUTH_CONSUMER'] = $consumer;

--- a/EOAuthUtils.php
+++ b/EOAuthUtils.php
@@ -38,11 +38,13 @@ class EOAuthUtils extends EOAuthComponent {
 
     // Set parameters.
     $params = array();
-    $params['scope'] = $scope;
-    if (isset($applicationName)) {
+    if ($scope) {
+    	$params['scope'] = $scope;
+    }
+    if ($applicationName) {
       $params['xoauth_displayname'] = $applicationName;
     }
-    if (isset($callbackUrl)) {
+    if ($callbackUrl) {
       $params['oauth_callback'] = $callbackUrl;
     }
 


### PR DESCRIPTION
Setting application name and some other params (eg scope) seems to break Yahoo OAuth authentication. This patch seems to fix it. Please consider merging.
