### PR TITLE
Update EOAuthUtils.php

### DIFF
--- a/EOAuthUtils.php
+++ b/EOAuthUtils.php
@@ -110,10 +110,11 @@ class EOAuthUtils extends EOAuthComponent {
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
     $response = curl_exec($ch);
     $headers = curl_getinfo($ch);
+    $error = curl_error($ch);
     curl_close($ch);
 
     if ($headers['http_code'] != 200) {
-      throw new OAuthException($response);
+      throw new OAuthException($error);
     }
 
     return self::GetTokenFromQueryString($response);


### PR DESCRIPTION
If i got error during curl request, the exception message will be an empty. I think we should show error message instead response, or we should combine this two strings.
